### PR TITLE
Fixed multiple entries for the same symbol

### DIFF
--- a/super32emu/super32emu/ui/emulator_widget.py
+++ b/super32emu/super32emu/ui/emulator_widget.py
@@ -139,10 +139,12 @@ class EmulatorWidget(QWidget):
     def set_symbols(self, symboltable: dict):
         """Fills the symboltable with parsed labels and addresses"""
 
-        for index in range(1, self.symbol_layout.rowCount()):
-            self.symbol_layout.removeRow(index)
+        num_rows = self.symbol_layout.rowCount()
+        for _ in range(1, num_rows):
+            self.symbol_layout.removeRow(1)
 
         font = QFont('Fira Code', 8, QFont.Medium)
+
         for entry in symboltable:
             symbol = QLineEdit()
             symbol.setReadOnly(True)


### PR DESCRIPTION
Instead of iterating through all rows from 1 to n, we have to call removeRow(1) n-1 times. The reason is that removeRow(int row) leads all rows to shift up one place.

Fixes #9 