### PR TITLE
Removed register blink

### DIFF
--- a/super32emu/super32emu/logic/emulator.py
+++ b/super32emu/super32emu/logic/emulator.py
@@ -20,7 +20,7 @@ class Emulator:
 
         self.emulator_widget.reset_all_registers()
 
-        self.emulator_widget.set_pc(0)
+        self.emulator_widget.set_pc(0, False)
         self.emulator_widget.set_storage(''.ljust(2**10, '0'))
         self.emulator_widget.set_symbols({"-": "-"})
 
@@ -52,6 +52,9 @@ class Emulator:
 
         logging.debug(f"Executing code address {self.row_counter * 4}")
 
+        self.emulator_widget.reset_highlighted_memory_lines()
+        self.emulator_widget.reset_all_register_backgrounds()
+
         instructionset = self.memory[self.row_counter]
         self.__parse_instructionset(instructionset)
         self.row_counter += 1
@@ -60,8 +63,6 @@ class Emulator:
 
         self.emulator_widget.set_storage(
             ''.join(self.memory).ljust(2 ** 10, '0'))
-
-        self.emulator_widget.reset_highlighted_memory_lines()
 
         self.emulator_widget.highlight_memory_line(self.row_counter)
         self.__highlight_editor_line()

--- a/super32emu/super32emu/ui/emulator_widget.py
+++ b/super32emu/super32emu/ui/emulator_widget.py
@@ -120,21 +120,32 @@ class EmulatorWidget(QWidget):
 
         return self.register[index].get_value()
 
-    def set_register(self, index, value, blink: bool = True):
+    def set_register_background(self, index, color = "white"):
+        """Resets the register background color"""
+        if index < 0 or index > 32:
+            raise Exception('Register out of index')
+
+        self.register[index].set_background_color(color)
+
+    def set_register(self, index, value, highlight: bool = True):
         """Sets the value of a register chosen by its index"""
         if index < 0 or index > 32:
             raise Exception('Register out of index')
 
-        self.register[index].set_value(str(value), blink)
+        self.register[index].set_value(str(value), highlight)
+
+    def reset_all_register_backgrounds(self):
+        for rindex in range(32):
+            self.set_register_background(rindex)
 
     def reset_all_registers(self):
         for rindex in range(32):
             self.set_register(rindex, '00000000', False)
 
-    def set_pc(self, value):
+    def set_pc(self, value, highlight: bool = True):
         """Sets the value of the program counter"""
 
-        self.program_counter.set_value(str(value))
+        self.program_counter.set_value(str(value), highlight=highlight, color="yellow")
 
     def set_storage(self, value):
         """Sets the value of the storage"""

--- a/super32emu/super32emu/ui/register_widget.py
+++ b/super32emu/super32emu/ui/register_widget.py
@@ -32,17 +32,16 @@ class RegisterWidget(QWidget):
         """Set the text of the label"""
         self.label.setText(text)
 
-    def __blink_color(self, color: str = "white"):
+    def set_background_color(self, color: str = "white"):
         self.text_input.setStyleSheet("background-color: " + color)
 
-    def set_value(self, value: str, blink: bool = True):
+    def set_value(self, value: str, highlight: bool = True, color: str = "#00ff00"):
         """Set the value of the register"""
         value = value.rjust(8, '0')
         self.text_input.setText(value)
 
-        if blink:
-            self.__blink_color("yellow")
-            QTimer.singleShot(2000, self.__blink_color)
+        if highlight:
+            self.set_background_color(color)
 
     def get_value(self):
         return self.text_input.text()


### PR DESCRIPTION
- Registers with changed content now stay highlighted indefinitely while the next command is not being executed
- Using green color to highlight changed content/memory access
- Yellow color is now exclusively used to highlight program counter position in code and memory

Fixes #42 